### PR TITLE
Add Docker Compose setup for ClaraVerse

### DIFF
--- a/README.docker-compose.md
+++ b/README.docker-compose.md
@@ -1,0 +1,117 @@
+# ClaraVerse Docker Compose Guide
+
+This guide helps you set up and run ClaraVerse and all its services using Docker Compose.
+
+## Prerequisites
+
+- Docker and Docker Compose installed on your system
+- At least 8GB of RAM (16GB recommended for running multiple AI models)
+- 20GB+ free disk space for models and data
+
+## Quick Start
+
+1. Clone this repository:
+   ```bash
+   git clone https://github.com/clara17verse/clara.git
+   cd clara
+   ```
+
+2. Start all services:
+   ```bash
+   docker compose up -d
+   ```
+
+3. Access ClaraVerse:
+   - Web UI: http://localhost:8069
+   - N8N: http://localhost:5678
+
+## Building the Images
+
+The docker-compose.yml file is configured to build the required ClaraVerse images locally:
+
+- `clara-app`: Main ClaraVerse UI built from the project's Dockerfile
+- `clara-backend`: Python backend service built from the py_backend/Dockerfile
+
+External services are pulled from Docker Hub:
+- `clara-interpreter`: Pulled from clara17verse/clara-interpreter:latest
+- `clara-n8n`: Pulled from n8nio/n8n:latest
+- `clara-ollama`: Pulled from ollama/ollama:latest
+
+## Services
+
+The docker-compose.yml file includes the following services:
+
+| Service | Description | Port | Container Name |
+|---------|-------------|------|---------------|
+| clara-app | Main ClaraVerse UI | 8069 | clara_app |
+| clara-backend | Python backend for file handling, RAG, etc. | 5001 | clara_python |
+| clara-interpreter | Code interpreter service | 8000 | clara_interpreter |
+| clara-n8n | N8N workflow automation | 5678 | clara_n8n |
+| clara-ollama | Ollama for running local AI models | 11434 | clara_ollama |
+
+## Volumes
+
+Persistent data is stored in the following Docker volumes:
+
+- `clara_data`: App settings and user data
+- `clara_interpreter_data`: Code interpreter files and environment
+- `clara_n8n_data`: N8N workflows and settings
+- `clara_ollama_data`: AI models and Ollama configuration
+
+## Managing Services
+
+### View running containers:
+```bash
+docker compose ps
+```
+
+### View logs:
+```bash
+docker compose logs -f clara-app  # View logs for the main app
+docker compose logs -f            # View all logs
+```
+
+### Stop all services:
+```bash
+docker compose down
+```
+
+### Restart a specific service:
+```bash
+docker compose restart clara-ollama
+```
+
+## Troubleshooting
+
+If you encounter issues:
+
+1. Check container logs for errors:
+   ```bash
+   docker compose logs -f <service-name>
+   ```
+
+2. Ensure all services are healthy:
+   ```bash
+   docker compose ps
+   ```
+
+3. Restart all services:
+   ```bash
+   docker compose down
+   docker compose up -d
+   ```
+
+4. For Ollama model issues, try accessing the Ollama API directly:
+   ```bash
+   curl http://localhost:11434/api/tags
+   ```
+
+## Advanced Configuration
+
+To modify ports or add custom environment variables, edit the `docker-compose.yml` file before running `docker compose up -d`.
+
+## Resources
+
+- [ClaraVerse Documentation](https://github.com/clara17verse/clara/docs)
+- [Ollama Documentation](https://github.com/ollama/ollama)
+- [N8N Documentation](https://docs.n8n.io/)

--- a/README.docker-compose.md
+++ b/README.docker-compose.md
@@ -33,8 +33,8 @@ The docker-compose.yml file is configured to build the required ClaraVerse image
 - `clara-backend`: Python backend service built from the py_backend/Dockerfile
 
 External services are pulled from Docker Hub:
-- `clara-interpreter`: Pulled from clara17verse/clara-interpreter:1.0.0
-- `clara-n8n`: Pulled from n8nio/n8n:0.234.0
+- `clara-interpreter`: Pulled from clara17verse/clara-interpreter:latest
+- `clara-n8n`: Pulled from n8nio/n8n:1.91.3
 - `clara-ollama`: Pulled from ollama/ollama:0.7.0
 
 ## Services

--- a/README.docker-compose.md
+++ b/README.docker-compose.md
@@ -12,8 +12,8 @@ This guide helps you set up and run ClaraVerse and all its services using Docker
 
 1. Clone this repository:
    ```bash
-   git clone https://github.com/clara17verse/clara.git
-   cd clara
+   git clone https://github.com/jeremywaller/ClaraVerse.git
+   cd ClaraVerse
    ```
 
 2. Start all services:
@@ -112,6 +112,6 @@ To modify ports or add custom environment variables, edit the `docker-compose.ym
 
 ## Resources
 
-- [ClaraVerse Documentation](https://github.com/clara17verse/clara/docs)
+- [ClaraVerse Documentation](https://github.com/jeremywaller/ClaraVerse)
 - [Ollama Documentation](https://github.com/ollama/ollama)
 - [N8N Documentation](https://docs.n8n.io/)

--- a/README.docker-compose.md
+++ b/README.docker-compose.md
@@ -33,21 +33,21 @@ The docker-compose.yml file is configured to build the required ClaraVerse image
 - `clara-backend`: Python backend service built from the py_backend/Dockerfile
 
 External services are pulled from Docker Hub:
-- `clara-interpreter`: Pulled from clara17verse/clara-interpreter:latest
-- `clara-n8n`: Pulled from n8nio/n8n:latest
-- `clara-ollama`: Pulled from ollama/ollama:latest
+- `clara-interpreter`: Pulled from clara17verse/clara-interpreter:1.0.0
+- `clara-n8n`: Pulled from n8nio/n8n:0.234.0
+- `clara-ollama`: Pulled from ollama/ollama:0.7.0
 
 ## Services
 
 The docker-compose.yml file includes the following services:
 
-| Service | Description | Port | Container Name |
-|---------|-------------|------|---------------|
-| clara-app | Main ClaraVerse UI | 8069 | clara_app |
-| clara-backend | Python backend for file handling, RAG, etc. | 5001 | clara_python |
-| clara-interpreter | Code interpreter service | 8000 | clara_interpreter |
-| clara-n8n | N8N workflow automation | 5678 | clara_n8n |
-| clara-ollama | Ollama for running local AI models | 11434 | clara_ollama |
+| Service | Description | Port Mapping | Container Name |
+|---------|-------------|-------------|---------------|
+| clara-app | Main ClaraVerse UI | 8069:8069 | clara_app |
+| clara-backend | Python backend for file handling, RAG, etc. | 5001:5000 | clara_python |
+| clara-interpreter | Code interpreter service | 8000:8000 | clara_interpreter |
+| clara-n8n | N8N workflow automation | 5678:5678 | clara_n8n |
+| clara-ollama | Ollama for running local AI models | 11434:11434 | clara_ollama |
 
 ## Volumes
 
@@ -109,6 +109,36 @@ If you encounter issues:
 ## Advanced Configuration
 
 To modify ports or add custom environment variables, edit the `docker-compose.yml` file before running `docker compose up -d`.
+
+### Environment Variables
+
+The following environment variables can be adjusted in the docker-compose.yml file:
+
+| Service | Variable | Description |
+|---------|----------|-------------|
+| clara-backend | PYTHONUNBUFFERED | Ensures Python output is sent directly to container logs |
+| clara-backend | OLLAMA_BASE_URL | URL for connecting to the Ollama API service |
+| clara-interpreter | PYTHONUNBUFFERED | Ensures Python output is sent directly to container logs |
+| clara-interpreter | OLLAMA_BASE_URL | URL for connecting to the Ollama API service |
+| clara-n8n | N8N_PORT | Port on which N8N will listen |
+| clara-n8n | N8N_PROTOCOL | Protocol for N8N connections (http/https) |
+| clara-n8n | N8N_HOST | Hostname for N8N service |
+| clara-n8n | WEBHOOK_URL | URL for webhook callbacks |
+| clara-n8n | N8N_EDITOR_BASE_URL | Base URL for the N8N editor UI |
+
+### Resource Limits
+
+All services have CPU and memory limits configured to prevent resource exhaustion:
+
+| Service | CPU Limit | Memory Limit |
+|---------|-----------|--------------|
+| clara-app | 1.0 | 1GB |
+| clara-backend | 0.5 | 512MB |
+| clara-interpreter | 0.8 | 1GB |
+| clara-n8n | 0.5 | 512MB |
+| clara-ollama | 2.0 | 4GB |
+
+These limits can be adjusted in the docker-compose.yml file based on your system capabilities.
 
 ## Resources
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,16 +1,33 @@
 services:
   # Main Clara frontend application
+  # All services have resource limits defined to prevent resource exhaustion
   clara-app:
     build:
       context: .
       dockerfile: Dockerfile
-    image: clara-ollama:latest
+    image: clara-app:latest
     container_name: clara_app
     ports:
       - "8069:8069"
+    depends_on:
+      - clara-backend
+      - clara-interpreter
+      - clara-n8n
+      - clara-ollama
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 1G
     networks:
       - clara_network
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8069"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
 
   # Python backend service
   clara-backend:
@@ -28,6 +45,11 @@ services:
       - OLLAMA_BASE_URL=http://clara_ollama:11434
     depends_on:
       - clara-ollama
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 512M
     networks:
       - clara_network
     restart: unless-stopped
@@ -40,7 +62,7 @@ services:
 
   # Clara Interpreter service
   clara-interpreter:
-    image: clara17verse/clara-interpreter:latest
+    image: clara17verse/clara-interpreter:1.0.0
     container_name: clara_interpreter
     ports:
       - "8000:8000"
@@ -51,6 +73,11 @@ services:
       - OLLAMA_BASE_URL=http://clara_ollama:11434
     depends_on:
       - clara-ollama
+    deploy:
+      resources:
+        limits:
+          cpus: '0.8'
+          memory: 1G
     networks:
       - clara_network
     restart: unless-stopped
@@ -63,7 +90,7 @@ services:
 
   # N8N Workflow automation service
   clara-n8n:
-    image: n8nio/n8n:latest
+    image: n8nio/n8n:0.234.0
     container_name: clara_n8n
     ports:
       - "5678:5678"
@@ -72,9 +99,14 @@ services:
     environment:
       - N8N_PORT=5678
       - N8N_PROTOCOL=http
-      - N8N_HOST=localhost
-      - WEBHOOK_URL=http://localhost:5678/
-      - N8N_EDITOR_BASE_URL=http://localhost:5678/
+      - N8N_HOST=clara-n8n
+      - WEBHOOK_URL=http://clara-n8n:5678/
+      - N8N_EDITOR_BASE_URL=http://clara-n8n:5678/
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 512M
     networks:
       - clara_network
     restart: unless-stopped
@@ -87,12 +119,17 @@ services:
 
   # Ollama service for local AI models
   clara-ollama:
-    image: ollama/ollama:latest
+    image: ollama/ollama:0.7.0
     container_name: clara_ollama
     ports:
       - "11434:11434"
     volumes:
       - clara_ollama_data:/root/.ollama
+    deploy:
+      resources:
+        limits:
+          cpus: '2.0'
+          memory: 4G
     networks:
       - clara_network
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
 
   # Clara Interpreter service
   clara-interpreter:
-    image: clara17verse/clara-interpreter:1.0.0
+    image: clara17verse/clara-interpreter:latest
     container_name: clara_interpreter
     ports:
       - "8000:8000"
@@ -90,7 +90,7 @@ services:
 
   # N8N Workflow automation service
   clara-n8n:
-    image: n8nio/n8n:0.234.0
+    image: n8nio/n8n:1.91.3
     container_name: clara_n8n
     ports:
       - "5678:5678"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,118 @@
+services:
+  # Main Clara frontend application
+  clara-app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: clara-ollama:latest
+    container_name: clara_app
+    ports:
+      - "8069:8069"
+    networks:
+      - clara_network
+    restart: unless-stopped
+
+  # Python backend service
+  clara-backend:
+    build:
+      context: ./py_backend
+      dockerfile: Dockerfile
+    image: clara-backend:latest
+    container_name: clara_python
+    ports:
+      - "5001:5000"
+    volumes:
+      - clara_data:/root/.clara
+    environment:
+      - PYTHONUNBUFFERED=1
+      - OLLAMA_BASE_URL=http://clara_ollama:11434
+    depends_on:
+      - clara-ollama
+    networks:
+      - clara_network
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 5s
+
+  # Clara Interpreter service
+  clara-interpreter:
+    image: clara17verse/clara-interpreter:latest
+    container_name: clara_interpreter
+    ports:
+      - "8000:8000"
+    volumes:
+      - clara_interpreter_data:/app/data
+    environment:
+      - PYTHONUNBUFFERED=1
+      - OLLAMA_BASE_URL=http://clara_ollama:11434
+    depends_on:
+      - clara-ollama
+    networks:
+      - clara_network
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 5s
+
+  # N8N Workflow automation service
+  clara-n8n:
+    image: n8nio/n8n:latest
+    container_name: clara_n8n
+    ports:
+      - "5678:5678"
+    volumes:
+      - clara_n8n_data:/home/node/.n8n
+    environment:
+      - N8N_PORT=5678
+      - N8N_PROTOCOL=http
+      - N8N_HOST=localhost
+      - WEBHOOK_URL=http://localhost:5678/
+      - N8N_EDITOR_BASE_URL=http://localhost:5678/
+    networks:
+      - clara_network
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5678/healthz"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 5s
+
+  # Ollama service for local AI models
+  clara-ollama:
+    image: ollama/ollama:latest
+    container_name: clara_ollama
+    ports:
+      - "11434:11434"
+    volumes:
+      - clara_ollama_data:/root/.ollama
+    networks:
+      - clara_network
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:11434/api/tags"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 5s
+
+networks:
+  clara_network:
+    driver: bridge
+
+volumes:
+  clara_data:
+    driver: local
+  clara_interpreter_data:
+    driver: local
+  clara_n8n_data:
+    driver: local
+  clara_ollama_data:
+    driver: local


### PR DESCRIPTION
## Summary
- Created docker-compose.yml file to run all ClaraVerse services in a single command
- Added comprehensive documentation in README.docker-compose.md
- Configured local building for main app and Python backend components
- Used published Docker images for external dependencies (n8n, ollama, interpreter)

## Test plan
1. Install Docker and Docker Compose
2. Run `docker compose up -d` from the project root
3. Check that all services start successfully
4. Verify web UI is accessible at http://localhost:8069
5. Verify N8N is accessible at http://localhost:5678
6. Verify Ollama API is accessible at http://localhost:11434/api/tags

🤖 Generated with [Claude Code](https://claude.ai/code)